### PR TITLE
Separate REDIS_URL into SPLIT_SYNC_* parameters programmatically

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -210,16 +210,16 @@ else
   if [ ! -z ${REDIS_URL+x} ]; then
     # REDIS_URL is in the form redis://:pass@host:port
     # Use : as delimiter on REDIS_URL in the form of pass@host, then separate into pass and host
-    CONNECTION_STRING=$(awk -F':' '{ print $3 }' <<< "$REDIS_URL")
+    CONNECTION_STRING=$(echo "$REDIS_URL" | awk -F':' '{ print $3 }')
 
     # Use @ as delimiter on CONNECTION_STRING to separate pass@host into pass (1) and host (2)
-    SPLIT_SYNC_REDIS_PASS=$(awk -F'@' '{ print $1 }' <<< "$CONNECTION_STRING")
+    SPLIT_SYNC_REDIS_PASS=$(echo "$CONNECTION_STRING" | awk -F'@' '{ print $1 }')
     PARAMETERS="${PARAMETERS} -redis-pass=${SPLIT_SYNC_REDIS_PASS}"
 
-    SPLIT_SYNC_REDIS_HOST=$(awk -F'@' '{ print $2 }' <<< "$CONNECTION_STRING")
+    SPLIT_SYNC_REDIS_HOST=$(echo "$CONNECTION_STRING" | awk -F'@' '{ print $2 }')
     PARAMETERS="${PARAMETERS} -redis-host=${SPLIT_SYNC_REDIS_HOST}"
 
-    SPLIT_SYNC_REDIS_PORT=$(awk -F':' '{ print $4 }' <<< "$REDIS_URL")
+    SPLIT_SYNC_REDIS_PORT=$(echo "$REDIS_URL" | awk -F':' '{ print $4 }')
     PARAMETERS="${PARAMETERS} -redis-port=${SPLIT_SYNC_REDIS_PORT}"
   fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -207,20 +207,24 @@ then
 else
   printf "Running in PRODUCER mode"
 
-  if [ ! -z ${SPLIT_SYNC_REDIS_HOST+x} ]; then
-    PARAMETERS="${PARAMETERS} -redis-host=${SPLIT_SYNC_REDIS_HOST}"
-  fi
+  if [ ! -z ${REDIS_URL+x} ]; then
+    # REDIS_URL is in the form redis://:pass@host:port
+    # Use : as delimiter on REDIS_URL in the form of pass@host, then separate into pass and host
+    CONNECTION_STRING=$(awk -F':' '{ print $3 }' <<< "$REDIS_URL")
 
-  if [ ! -z ${SPLIT_SYNC_REDIS_PORT+x} ]; then
+    # Use @ as delimiter on CONNECTION_STRING to separate pass@host into pass (1) and host (2)
+    SPLIT_SYNC_REDIS_PASS=$(awk -F'@' '{ print $1 }' <<< "$CONNECTION_STRING")
+    PARAMETERS="${PARAMETERS} -redis-pass=${SPLIT_SYNC_REDIS_PASS}"
+
+    SPLIT_SYNC_REDIS_HOST=$(awk -F'@' '{ print $2 }' <<< "$CONNECTION_STRING")
+    PARAMETERS="${PARAMETERS} -redis-host=${SPLIT_SYNC_REDIS_HOST}"
+
+    SPLIT_SYNC_REDIS_PORT=$(awk -F':' '{ print $4 }' <<< "$REDIS_URL")
     PARAMETERS="${PARAMETERS} -redis-port=${SPLIT_SYNC_REDIS_PORT}"
   fi
 
   if [ ! -z ${SPLIT_SYNC_REDIS_DB+x} ]; then
     PARAMETERS="${PARAMETERS} -redis-db=${SPLIT_SYNC_REDIS_DB}"
-  fi
-
-  if [ ! -z ${SPLIT_SYNC_REDIS_PASS+x} ]; then
-    PARAMETERS="${PARAMETERS} -redis-pass=${SPLIT_SYNC_REDIS_PASS}"
   fi
 
   if [ ! -z ${SPLIT_SYNC_REDIS_PREFIX+x} ]; then


### PR DESCRIPTION
## Original behavior
I helped Michael Branon with some Split work on Bridge this week. We discovered that the [Heroku Redis attachment cycles credentials periodically](https://help.heroku.com/VN3D085X/why-have-my-heroku-redis-credentials-changed), which breaks some assumptions we have around how the synchronizer should work. Namely, the Heroku Redis attachment can change the `REDIS_URL` but won't know to update the `SPLIT_SYNC_REDIS_HOST`, `SPLIT_SYNC_REDIS_PORT`, or `SPLIT_SYNC_REDIS_PASS` variables. This would lead to us not using the right Redis cache for the Split synchronizer, and we'd time out and error out on any non-SDK-cached entries.

In this case, we need to avoid hardcoding the `SPLIT_SYNC_REDIS_*` variables since they can cycle, and we should instead programmatically parse them out of the `REDIS_URL` that gets cycled.

See Split docs on the [synchronizer](https://help.split.io/hc/en-us/articles/360019686092-Split-synchronizer-proxy), [deploying synchronizer to Heroku](https://help.split.io/hc/en-us/articles/360033291832-How-to-deploy-Synchronizer-Docker-Container-in-Heroku-), and their [best practices for the synchronizer](https://help.split.io/hc/en-us/articles/360018343391-Split-Synchronizer-Runbook) for details.

NOTE: this is work related to our non-`split-synchronizer` repositories: since the Heroku Redis attachment does update the `REDIS_URL` variable and restarts attached apps, we can add the same Heroku Redis attachment to every app consuming Split. This would propogate the `REDIS_URL` update such that every downstream app would be updated as well. We need to split that URL into the needed `SPLIT_SYNC_REDIS_*` variables ourselves rather than hard coding them in apps' `settings.py` files or other setup files. This would, however, result in every credential rotation restarting all of our apps since the Heroku Redis attachment updates the `REDIS_URL` and restarts downstream apps.

## With these changes
In order to accomodate the `REDIS_URL` changing periodically, I modified the `entrypoint.sh` here to parse out `SPLIT_SYNC_REDIS_HOST`, `SPLIT_SYNC_REDIS_PASS`, and `SPLIT_SYNC_REDIS_PORT` using `awk`. It's been a little while since I've been fluent in `bash`, so if anyone has a cleaner way of doing this, let me know.

## Testing
I removed the `SPLIT_SYNC_REDIS_*` config vars from `stp-split-sync--staging` and it is still able to startup. With invalid credentials, it would crash and restart, which is not happening. I also see syncs happening in the logs, showing that it's pulling from split and pushing to Redis properly. I also used my split testing branch to validate that I am able to receive splits from the redis cache.